### PR TITLE
Add copy feature on group show page #108

### DIFF
--- a/public/css/main.scss
+++ b/public/css/main.scss
@@ -51,18 +51,8 @@ article.message.alert-detail {
 
 // Bulma components. The order matters, add new components
 // after the `base/_all` import
-@import "../../node_modules/bulma/sass/utilities/_all.sass";
-@import "../../node_modules/bulma/sass/base/_all.sass";
-@import "../../node_modules/bulma/sass/elements/_all.sass";
+@import "../../node_modules/bulma/bulma.sass";
 
-@import "../../node_modules/bulma/sass/components/card.sass";
-@import "../../node_modules/bulma/sass/components/message.sass";
-@import "../../node_modules/bulma/sass/components/navbar.sass";
-@import "../../node_modules/bulma/sass/components/pagination.sass";
-@import "../../node_modules/bulma/sass/components/menu.sass";
-
-@import "../../node_modules/bulma/sass/form/_all.sass";
-@import "../../node_modules/bulma/sass/grid/columns.sass";
 @import "../../node_modules/bulma-tooltip/src/sass/index.sass";
 @import "../../node_modules/@creativebulma/bulma-tagsinput/src/sass/index.sass";
 

--- a/public/js/group.js
+++ b/public/js/group.js
@@ -10,3 +10,17 @@ const deleteGroup = id => {
       .catch(err => console.error(err))
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const copyGroup = id => {
+  location.href = `/groups/copy/${id}`
+}
+
+const dropdown = document.querySelector('.dropdown')
+dropdown.addEventListener('click', event => {
+  event.stopPropagation()
+  dropdown.classList.toggle('is-active')
+})
+document.addEventListener('click', () => {
+  dropdown.classList.remove('is-active')
+})

--- a/public/js/group.js
+++ b/public/js/group.js
@@ -11,11 +11,6 @@ const deleteGroup = id => {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const copyGroup = id => {
-  location.href = `/groups/copy/${id}`
-}
-
 const dropdown = document.querySelector('.dropdown')
 dropdown.addEventListener('click', event => {
   event.stopPropagation()

--- a/public/js/md-editor.js
+++ b/public/js/md-editor.js
@@ -36,3 +36,7 @@ const easyMDE = new EasyMDE({
     }
   }]
 })
+
+if (typeof description !== 'undefined') {
+  easyMDE.value(description)
+}

--- a/public/js/md-editor.js
+++ b/public/js/md-editor.js
@@ -37,6 +37,6 @@ const easyMDE = new EasyMDE({
   }]
 })
 
-if (typeof description !== 'undefined') {
+if (description != null) {
   easyMDE.value(description)
 }

--- a/public/js/md-editor.js
+++ b/public/js/md-editor.js
@@ -37,6 +37,6 @@ const easyMDE = new EasyMDE({
   }]
 })
 
-if (description != null) {
+if (typeof description !== 'undefined' && description !== null) {
   easyMDE.value(description)
 }

--- a/src/components/groups/group.routes.ts
+++ b/src/components/groups/group.routes.ts
@@ -59,7 +59,7 @@ router.delete('/:id',
   (req, res) => res.status(204).send('Csoport sikeresen törölve')
 )
 
-router.get('/copy/:id', isAuthenticated, getGroup, (req, res) =>
+router.get('/:id/copy', isAuthenticated, getGroup, (req, res) =>
   res.render('group/new', {
     roomId: req.group.room,
     name: req.group.name,

--- a/src/components/groups/group.routes.ts
+++ b/src/components/groups/group.routes.ts
@@ -59,4 +59,14 @@ router.delete('/:id',
   (req, res) => res.status(204).send('Csoport sikeresen törölve')
 )
 
+router.get('/copy/:id', isAuthenticated, getGroup, (req, res) =>
+  res.render('group/new', {
+    roomId: req.group.room,
+    name: req.group.name,
+    description: req.group.description,
+    tags: req.group.tags,
+    ROOMS
+  })
+)
+
 export default router

--- a/src/components/groups/group.service.ts
+++ b/src/components/groups/group.service.ts
@@ -26,7 +26,10 @@ export const getGroup = async (req: Request, res: Response, next: NextFunction) 
     .withGraphFetched('users')
 
   if (group) {
-    req.group = { ...group, description: formatMdToSafeHTML(group.description) } as Group
+    if (req.path.includes('/copy'))
+      req.group = group
+    else
+      req.group = { ...group, description: formatMdToSafeHTML(group.description) } as Group
     next()
   } else {
     res.render('error/not-found')

--- a/views/group/new.pug
+++ b/views/group/new.pug
@@ -11,11 +11,11 @@ block content
     .field
       label.label(for="name") Csoport neve
       .control
-        input.input(type="text", name="name", id="name", placeholder="Analízis ZH1 készülés" required)
+        input.input(type="text", name="name", id="name", placeholder="Analízis ZH1 készülés", value=`${name? name : ''}`, required)
     .field
       label.label Címkék (8)
       .control
-        input.input(type="tags", name="tags", id="tags", placeholder="Adj hozzá címkéket...")
+        input.input(type="tags", name="tags", id="tags", placeholder="Adj hozzá címkéket...", value=`${tags? tags : ''}`)
     .field
       label.label(for="room") Szint
       .control
@@ -55,6 +55,8 @@ block content
 block scripts
   if start && end
     script const range = { start: !{JSON.stringify(start)}, end: !{JSON.stringify(end)} }
+  if description
+    script const description = !{JSON.stringify(description)}
   script(src="https://cdn.jsdelivr.net/npm/flatpickr")
   script(src="/js/picker.js")
   script(src="https://unpkg.com/easymde@2.10.1/dist/easymde.min.js")

--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -3,13 +3,28 @@ extends ../layouts/main
 block content
   .group-show
     .columns
-      .column
-        h1.title= group.name
       .column.is-narrow
-        if isOwner
-          button.button.is-danger(type="button", onclick=`deleteGroup(${group.id})`) 
-            i.fas.fa-trash-alt
-            span &nbsp;Törlés
+        h1.title= group.name
+      .column.has-text-right
+        .dropdown.is-right
+          .dropdown-trigger
+            button.button(aria-haspopup="true", aria-controls="dropdown-menu")
+              span.icon
+                i.fas.fa-sliders-h
+              span.icon.is-small
+                i.fas.fa-angle-down
+          .dropdown-menu(id="dropdown-menu", role="menu")
+            .dropdown-content
+              a.dropdown-item(onclick=`copyGroup(${group.id})`)
+                span.icon
+                  i.fas.fa-copy
+                span &nbsp;Másolás
+              if isOwner
+                hr.dropdown-divider
+                a.dropdown-item(onclick=`deleteGroup(${group.id})`)
+                  span.icon.has-text-danger
+                    i.fas.fa-trash-alt
+                  span.has-text-danger &nbsp;Törlés
 
     - const [startDate, startTime] = format(group.startDate, DATE_FORMAT).split(' ')
     - const [endDate, endTime] = format(group.endDate, DATE_FORMAT).split(' ')

--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -15,7 +15,7 @@ block content
                 i.fas.fa-angle-down
           .dropdown-menu(id="dropdown-menu", role="menu")
             .dropdown-content
-              a.dropdown-item(onclick=`copyGroup(${group.id})`)
+              a.dropdown-item(href=`/groups/${group.id}/copy`)
                 span.icon
                   i.fas.fa-copy
                 span &nbsp;Másolás


### PR DESCRIPTION
Closes #108 

### What's new:
* Dropdown menu on group show page
* Copy button redirects to new group page with data: _name, room, tags, description_ (_startDate, endDate_ and _doNotDisturb_ attributes are not to be copied)
* GetGroup is modified so the markdown will get passed on copy

### Idea to consider:
Right now we have a **Copy** button, but we might just want to implement another button with **Copy with participants** button, so that the user could invite the participants already.