### PR TITLE
Fix vertical space between tags on group show #333

### DIFF
--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -82,7 +82,7 @@ block content
                 i.fas.fa-fw.fa-tags
               each tag in group.tags.split(",")
                 span &nbsp;
-                span.tag.is-info.is-medium= tag
+                span.tag.is-info.is-medium.mb-1= tag
 
     if group.description
       p.menu-label Leírás


### PR DESCRIPTION
Closes #333 

### What's new:
Will put a small bottom margin between the tags, to separate them, making aesthetically pleasing to the eye. 🎨 