### PR TITLE
Async middleware error handling

### DIFF
--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -7,8 +7,9 @@ import { differenceInMinutes } from 'date-fns'
 
 import { User } from '../users/user'
 import { Group } from './group'
+import { asyncWrapper } from '../../util/asyncWrapper'
 
-export const joinGroup = async (req: Request, res: Response, next: NextFunction) => {
+export const joinGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const user = req.user as User
   const group = req.group
 
@@ -19,24 +20,23 @@ export const joinGroup = async (req: Request, res: Response, next: NextFunction)
       .relate(user.id)
   }
   next()
-}
-
-export const leaveGroup = async (req: Request, res: Response, next: NextFunction) => {
+});
+export const leaveGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   await Group.relatedQuery('users')
     .for(req.group.id)
     .unrelate()
     .where('user_id', (req.user as User).id)
 
   next()
-}
+});
 
-export const isGroupOwner = async (req: Request, res: Response, next: NextFunction) => {
+export const isGroupOwner = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   if ((req.user as User)?.id === req.group.ownerId) {
     next()
   } else {
     res.render('error/forbidden')
   }
-}
+});
 
 export const createICSEvent = (req: Request, res: Response) => {
   const group = req.group
@@ -119,7 +119,7 @@ export const validateGroup = () => {
   ]
 }
 
-export const checkConflicts = async (req: Request, res: Response, next: NextFunction) => {
+export const checkConflicts = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const group = req.body as Group
   const conflictingGroups = await Group.query()
     .where({ room: group.room })
@@ -147,4 +147,4 @@ export const checkConflicts = async (req: Request, res: Response, next: NextFunc
   } else {
     next()
   }
-}
+});

--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -20,7 +20,7 @@ export const joinGroup = asyncWrapper(async (req: Request, res: Response, next: 
       .relate(user.id)
   }
   next()
-});
+})
 export const leaveGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   await Group.relatedQuery('users')
     .for(req.group.id)
@@ -28,15 +28,16 @@ export const leaveGroup = asyncWrapper(async (req: Request, res: Response, next:
     .where('user_id', (req.user as User).id)
 
   next()
-});
+})
 
-export const isGroupOwner = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
-  if ((req.user as User)?.id === req.group.ownerId) {
-    next()
-  } else {
-    res.render('error/forbidden')
-  }
-});
+export const isGroupOwner = asyncWrapper(
+  async (req: Request, res: Response, next: NextFunction) => {
+    if ((req.user as User)?.id === req.group.ownerId) {
+      next()
+    } else {
+      res.render('error/forbidden')
+    }
+  })
 
 export const createICSEvent = (req: Request, res: Response) => {
   const group = req.group
@@ -119,32 +120,33 @@ export const validateGroup = () => {
   ]
 }
 
-export const checkConflicts = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
-  const group = req.body as Group
-  const conflictingGroups = await Group.query()
-    .where({ room: group.room })
-    .andWhere(builder => {
-      builder
-        .where(bld => {
-          bld
-            .where('startDate', '<', group.endDate)
-            .andWhere('endDate', '>=', group.endDate)
-        })
-        .orWhere(bld => {
-          bld
-            .where('endDate', '>', group.startDate)
-            .andWhere('endDate', '<=', group.endDate)
-        })
-    })
+export const checkConflicts = asyncWrapper(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const group = req.body as Group
+    const conflictingGroups = await Group.query()
+      .where({ room: group.room })
+      .andWhere(builder => {
+        builder
+          .where(bld => {
+            bld
+              .where('startDate', '<', group.endDate)
+              .andWhere('endDate', '>=', group.endDate)
+          })
+          .orWhere(bld => {
+            bld
+              .where('endDate', '>', group.startDate)
+              .andWhere('endDate', '<=', group.endDate)
+          })
+      })
 
-  if (conflictingGroups.length) {
-    res.status(400).json(
-      {
-        errors: conflictingGroups.map(group =>
-          ({ msg: `Az időpont ütközik a(z) ${group.name} csoporttal` }))
-      }
-    )
-  } else {
-    next()
-  }
-});
+    if (conflictingGroups.length) {
+      res.status(400).json(
+        {
+          errors: conflictingGroups.map(group =>
+            ({ msg: `Az időpont ütközik a(z) ${group.name} csoporttal` }))
+        }
+      )
+    } else {
+      next()
+    }
+  })

--- a/src/components/groups/group.service.ts
+++ b/src/components/groups/group.service.ts
@@ -3,8 +3,9 @@ import { Request, Response, NextFunction} from 'express'
 import { Group } from './group'
 import { User } from '../users/user'
 import { formatMdToSafeHTML } from '../../util/convertMarkdown'
+import { asyncWrapper } from '../../util/asyncWrapper';
 
-export const getGroups = async (req: Request, res: Response, next: NextFunction) => {
+export const getGroups = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const page = parseInt(req.query.page ?? 0)
   const limit = 10
   const pageObject = await Group.query().orderBy('createdAt', 'DESC').page(page, limit)
@@ -19,9 +20,9 @@ export const getGroups = async (req: Request, res: Response, next: NextFunction)
     current: page
   }
   next()
-}
+});
 
-export const getGroup = async (req: Request, res: Response, next: NextFunction) => {
+export const getGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const group = await Group.query()
     .findOne({ id: parseInt(req.params.id) })
     .withGraphFetched('users')
@@ -35,9 +36,9 @@ export const getGroup = async (req: Request, res: Response, next: NextFunction) 
   } else {
     res.render('error/not-found')
   }
-}
+});
 
-export const createGroup = async (req: Request, res: Response, next: NextFunction) => {
+export const createGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   req.group = await Group.query()
     .insert(
       {
@@ -53,9 +54,9 @@ export const createGroup = async (req: Request, res: Response, next: NextFunctio
     )
 
   next()
-}
+});
 
-export const removeGroup = async (req: Request, res: Response, next: NextFunction) => {
+export const removeGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   await Group.transaction(async trx => {
     await Group.relatedQuery('users', trx)
       .for(req.group.id)
@@ -65,4 +66,4 @@ export const removeGroup = async (req: Request, res: Response, next: NextFunctio
   })
 
   next()
-}
+});

--- a/src/components/groups/group.service.ts
+++ b/src/components/groups/group.service.ts
@@ -3,7 +3,7 @@ import { Request, Response, NextFunction} from 'express'
 import { Group } from './group'
 import { User } from '../users/user'
 import { formatMdToSafeHTML } from '../../util/convertMarkdown'
-import { asyncWrapper } from '../../util/asyncWrapper';
+import { asyncWrapper } from '../../util/asyncWrapper'
 
 export const getGroups = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const page = parseInt(req.query.page ?? 0)
@@ -20,7 +20,7 @@ export const getGroups = asyncWrapper(async (req: Request, res: Response, next: 
     current: page
   }
   next()
-});
+})
 
 export const getGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const group = await Group.query()
@@ -36,7 +36,7 @@ export const getGroup = asyncWrapper(async (req: Request, res: Response, next: N
   } else {
     res.render('error/not-found')
   }
-});
+})
 
 export const createGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   req.group = await Group.query()
@@ -54,7 +54,7 @@ export const createGroup = asyncWrapper(async (req: Request, res: Response, next
     )
 
   next()
-});
+})
 
 export const removeGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   await Group.transaction(async trx => {
@@ -66,4 +66,4 @@ export const removeGroup = asyncWrapper(async (req: Request, res: Response, next
   })
 
   next()
-});
+})

--- a/src/components/rooms/room.routes.ts
+++ b/src/components/rooms/room.routes.ts
@@ -1,22 +1,23 @@
-import { Request, Response, Router } from 'express'
+import { Request, Response, Router, NextFunction } from 'express'
 
 import { getBusyRooms, getEventsForRoom } from './room.service'
 import { ROOMS } from '../../util/constants'
+import { asyncWrapper } from '../../util/asyncWrapper';
 
-export const index = async (req: Request, res: Response) => {
+export const index = asyncWrapper(async (req: Request, res: Response) => {
   const busyRooms = await getBusyRooms()
   res.render('room/index', { busyRooms, ROOMS })
-}
+});
 
-const show = async (req: Request, res: Response) => {
+const show = asyncWrapper(async (req: Request, res: Response) => {
   if (+req.params.id <= 18 && +req.params.id >= 3) {
     res.render('room/calendar', { room: req.params.id })
   } else {
     res.redirect('/not-found')
   }
-}
+});
 
-const getGroupsForRoom = async (req: Request, res: Response) => {
+const getGroupsForRoom = asyncWrapper(async (req: Request, res: Response, _next:NextFunction) => {
   const events = await getEventsForRoom(+req.params.id)
   res.json(
     events.map(event => ({
@@ -26,7 +27,7 @@ const getGroupsForRoom = async (req: Request, res: Response) => {
       groupId: event.id
     }))
   )
-}
+});
 
 const router = Router()
 

--- a/src/components/rooms/room.routes.ts
+++ b/src/components/rooms/room.routes.ts
@@ -17,7 +17,7 @@ const show = asyncWrapper(async (req: Request, res: Response) => {
   }
 });
 
-const getGroupsForRoom = asyncWrapper(async (req: Request, res: Response, _next:NextFunction) => {
+const getGroupsForRoom = asyncWrapper(async (req: Request, res: Response, _next: NextFunction) => {
   const events = await getEventsForRoom(+req.params.id)
   res.json(
     events.map(event => ({

--- a/src/components/rooms/room.routes.ts
+++ b/src/components/rooms/room.routes.ts
@@ -2,12 +2,12 @@ import { Request, Response, Router, NextFunction } from 'express'
 
 import { getBusyRooms, getEventsForRoom } from './room.service'
 import { ROOMS } from '../../util/constants'
-import { asyncWrapper } from '../../util/asyncWrapper';
+import { asyncWrapper } from '../../util/asyncWrapper'
 
 export const index = asyncWrapper(async (req: Request, res: Response) => {
   const busyRooms = await getBusyRooms()
   res.render('room/index', { busyRooms, ROOMS })
-});
+})
 
 const show = asyncWrapper(async (req: Request, res: Response) => {
   if (+req.params.id <= 18 && +req.params.id >= 3) {
@@ -15,7 +15,7 @@ const show = asyncWrapper(async (req: Request, res: Response) => {
   } else {
     res.redirect('/not-found')
   }
-});
+})
 
 const getGroupsForRoom = asyncWrapper(async (req: Request, res: Response, _next: NextFunction) => {
   const events = await getEventsForRoom(+req.params.id)
@@ -27,7 +27,7 @@ const getGroupsForRoom = asyncWrapper(async (req: Request, res: Response, _next:
       groupId: event.id
     }))
   )
-});
+})
 
 const router = Router()
 

--- a/src/components/rooms/room.routes.ts
+++ b/src/components/rooms/room.routes.ts
@@ -1,4 +1,4 @@
-import { Request, Response, Router, NextFunction } from 'express'
+import { Request, Response, Router } from 'express'
 
 import { getBusyRooms, getEventsForRoom } from './room.service'
 import { ROOMS } from '../../util/constants'
@@ -17,7 +17,7 @@ const show = asyncWrapper(async (req: Request, res: Response) => {
   }
 })
 
-const getGroupsForRoom = asyncWrapper(async (req: Request, res: Response, _next: NextFunction) => {
+const getGroupsForRoom = asyncWrapper(async (req: Request, res: Response) => {
   const events = await getEventsForRoom(+req.params.id)
   res.json(
     events.map(event => ({

--- a/src/components/tickets/ticket.service.ts
+++ b/src/components/tickets/ticket.service.ts
@@ -2,7 +2,7 @@ import { Ticket } from './ticket'
 import { Request, Response, NextFunction } from 'express'
 
 import { formatMdToSafeHTML } from '../../util/convertMarkdown'
-import { asyncWrapper } from '../../util/asyncWrapper';
+import { asyncWrapper } from '../../util/asyncWrapper'
 
 export const getTickets = asyncWrapper(async (req: Request, _res: Response, next: NextFunction) => {
   req.tickets = (await Ticket.query().orderBy('createdAt', 'ASC')).map(ticket => {
@@ -10,32 +10,34 @@ export const getTickets = asyncWrapper(async (req: Request, _res: Response, next
     return ticket
   })
   next()
-});
+})
 
-export const createTicket = asyncWrapper(async (req: Request, _res: Response, next: NextFunction) => {
-  await Ticket.transaction(async trx => {
-    return await Ticket.query(trx)
-      .insert(
-        {
-          roomNumber: +req.body.roomNumber,
-          description: req.body.description
-        }
-      )
+export const createTicket = asyncWrapper(
+  async (req: Request, _res: Response, next: NextFunction) => {
+    await Ticket.transaction(async trx => {
+      return await Ticket.query(trx)
+        .insert(
+          {
+            roomNumber: +req.body.roomNumber,
+            description: req.body.description
+          }
+        )
+    })
+    next()
   })
-  next()
-});
 
-export const removeTicket = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
-  const id = parseInt(req.params.id)
-  if (!isNaN(id)) {
-    const deletedCount = await Ticket.query().deleteById(id)
+export const removeTicket = asyncWrapper(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const id = parseInt(req.params.id)
+    if (!isNaN(id)) {
+      const deletedCount = await Ticket.query().deleteById(id)
 
-    if (deletedCount === 0) {
-      res.status(404).send({ message: 'Nem található hibajegy a megadott ID-val' })
+      if (deletedCount === 0) {
+        res.status(404).send({ message: 'Nem található hibajegy a megadott ID-val' })
+      } else {
+        next()
+      }
     } else {
-      next()
+      res.status(404).send({ message: 'A megadott ID nem megfelelő formátumú' })
     }
-  } else {
-    res.status(404).send({ message: 'A megadott ID nem megfelelő formátumú' })
-  }
-});
+  })

--- a/src/components/tickets/ticket.service.ts
+++ b/src/components/tickets/ticket.service.ts
@@ -2,16 +2,17 @@ import { Ticket } from './ticket'
 import { Request, Response, NextFunction } from 'express'
 
 import { formatMdToSafeHTML } from '../../util/convertMarkdown'
+import { asyncWrapper } from '../../util/asyncWrapper';
 
-export const getTickets = async (req: Request, _res: Response, next: NextFunction) => {
+export const getTickets = asyncWrapper(async (req: Request, _res: Response, next: NextFunction) => {
   req.tickets = (await Ticket.query().orderBy('createdAt', 'ASC')).map(ticket => {
     ticket.description = formatMdToSafeHTML(ticket.description)
     return ticket
   })
   next()
-}
+});
 
-export const createTicket = async (req: Request, _res: Response, next: NextFunction) => {
+export const createTicket = asyncWrapper(async (req: Request, _res: Response, next: NextFunction) => {
   await Ticket.transaction(async trx => {
     return await Ticket.query(trx)
       .insert(
@@ -22,9 +23,9 @@ export const createTicket = async (req: Request, _res: Response, next: NextFunct
       )
   })
   next()
-}
+});
 
-export const removeTicket = async (req: Request, res: Response, next: NextFunction) => {
+export const removeTicket = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const id = parseInt(req.params.id)
   if (!isNaN(id)) {
     const deletedCount = await Ticket.query().deleteById(id)
@@ -37,4 +38,4 @@ export const removeTicket = async (req: Request, res: Response, next: NextFuncti
   } else {
     res.status(404).send({ message: 'A megadott ID nem megfelelő formátumú' })
   }
-}
+});

--- a/src/components/users/user.service.ts
+++ b/src/components/users/user.service.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 
 import { User } from './user'
+import { asyncWrapper } from '../../util/asyncWrapper';
 
 interface OAuthUser {
   displayName: string
@@ -8,7 +9,7 @@ interface OAuthUser {
   mail: string
 }
 
-export const getUser = async (req: Request, res: Response, next: NextFunction) => {
+export const getUser = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const user = await User.query()
     .findOne({ id: parseInt(req.params.id) })
     .withGraphFetched('groups(orderByEndDate)')
@@ -24,9 +25,9 @@ export const getUser = async (req: Request, res: Response, next: NextFunction) =
     req.userToShow = user
     next()
   }
-}
+});
 
-export const toggleAdmin = async (req: Request, res: Response, next: NextFunction) => {
+export const toggleAdmin = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const user = await User.query().findOne({ id: parseInt(req.params.id) })
 
   if (!user) {
@@ -37,14 +38,14 @@ export const toggleAdmin = async (req: Request, res: Response, next: NextFunctio
       .where({ id: user.id })
     next()
   }
-}
+});
 
-export const updateUser = async (req: Request, res: Response, next: NextFunction) => {
+export const updateUser = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const id = (req.user as User).id
   req.user = await User.query().patchAndFetchById(id, { ...req.body })
 
   next()
-}
+});
 
 export const createUser = async (user: OAuthUser) => {
   return await User.transaction(async trx => {

--- a/src/components/users/user.service.ts
+++ b/src/components/users/user.service.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 
 import { User } from './user'
-import { asyncWrapper } from '../../util/asyncWrapper';
+import { asyncWrapper } from '../../util/asyncWrapper'
 
 interface OAuthUser {
   displayName: string
@@ -25,7 +25,7 @@ export const getUser = asyncWrapper(async (req: Request, res: Response, next: Ne
     req.userToShow = user
     next()
   }
-});
+})
 
 export const toggleAdmin = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const user = await User.query().findOne({ id: parseInt(req.params.id) })
@@ -38,14 +38,14 @@ export const toggleAdmin = asyncWrapper(async (req: Request, res: Response, next
       .where({ id: user.id })
     next()
   }
-});
+})
 
 export const updateUser = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const id = (req.user as User).id
   req.user = await User.query().patchAndFetchById(id, { ...req.body })
 
   next()
-});
+})
 
 export const createUser = async (user: OAuthUser) => {
   return await User.transaction(async trx => {

--- a/src/util/asyncWrapper.ts
+++ b/src/util/asyncWrapper.ts
@@ -1,0 +1,1 @@
+export const asyncWrapper = fn => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);

--- a/src/util/asyncWrapper.ts
+++ b/src/util/asyncWrapper.ts
@@ -1,1 +1,4 @@
-export const asyncWrapper = fn => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
+export const asyncWrapper = fn => (req, res, next) => 
+  Promise
+    .resolve(fn(req, res, next))
+    .catch(next)

--- a/src/util/asyncWrapper.ts
+++ b/src/util/asyncWrapper.ts
@@ -1,4 +1,7 @@
-export const asyncWrapper = fn => (req, res, next) => 
+import { Request, Response , NextFunction } from 'express'
+
+
+export const asyncWrapper = fn => (req: Request, res: Response, next: NextFunction) => 
   Promise
     .resolve(fn(req, res, next))
     .catch(next)


### PR DESCRIPTION
So after some reading, the main problem with the error handling is that Express can't catch errors of promises and async functions. One solution would be to use `try - catch` in every async middleware, but i think its much cleaner if we wrap these async middlewares in a promise.
This way it forwards the catched error to the default Express error handler.

closes #339 