### PR TITLE
Allow admins to have control over any group

### DIFF
--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -31,6 +31,9 @@ export const leaveGroup = asyncWrapper(async (req: Request, res: Response, next:
   next()
 })
 
+/**
+ * @deprecated use isGroupOwnerOrAdmin instead 
+ */
 export const isGroupOwner = asyncWrapper(
   async (req: Request, res: Response, next: NextFunction) => {
     if ((req.user as User)?.id === req.group.ownerId) {
@@ -38,7 +41,18 @@ export const isGroupOwner = asyncWrapper(
     } else {
       res.render('error/forbidden')
     }
-  })
+  }
+)
+
+export const isGroupOwnerOrAdmin = asyncWrapper(
+  async (req: Request, res: Response, next: NextFunction) => {
+    if (((req.user as User)?.id === req.group.ownerId) || ((req.user as User)?.admin)) {
+      next()
+    } else {
+      res.render('error/forbidden')
+    }
+  }
+)
 
 export const createICSEvent = (req: Request, res: Response) => {
   const group = req.group

--- a/src/components/groups/group.routes.ts
+++ b/src/components/groups/group.routes.ts
@@ -12,12 +12,12 @@ import { DATE_FORMAT, ROOMS } from '../../util/constants'
 import { handleValidationError, checkIdParam } from '../../util/validators'
 import { User } from '../users/user'
 import {
-  isGroupOwner,
   joinGroup,
   leaveGroup,
   createICSEvent,
   checkConflicts,
-  validateGroup
+  validateGroup, 
+  isGroupOwnerOrAdmin
 } from './group.middlewares'
 import { createGroup, getGroup, getGroups, updateGroup, removeGroup } from './group.service'
 
@@ -64,8 +64,9 @@ router.get('/:id',
   (req, res) => {
     const joined = req.group.users.some(u => u.id === (req.user as User).id)
     const isOwner = req.group.ownerId === (req.user as User).id
+    const isAdmin = (req.user as User).admin
     res.render('group/show', {
-      group: req.group, joined, isOwner, format, DATE_FORMAT
+      group: req.group, joined, isOwner, format, DATE_FORMAT, isAdmin
     })
   })
 
@@ -86,7 +87,7 @@ router.post('/:id/leave',
 router.delete('/:id',
   isAuthenticated,
   getGroup,
-  isGroupOwner,
+  isGroupOwnerOrAdmin,
   removeGroup,
   (req, res) => res.status(204).send('Csoport sikeresen törölve')
 )
@@ -109,7 +110,7 @@ router.get('/:id/edit',
   isAuthenticated,
   checkIdParam,
   getGroup,
-  isGroupOwner,
+  isGroupOwnerOrAdmin,
   (req, res) =>
     res.render('group/new', {
       roomId: req.group.room,
@@ -129,7 +130,7 @@ router.put('/:id',
   isAuthenticated,
   checkIdParam,
   getGroup,
-  isGroupOwner,
+  isGroupOwnerOrAdmin,
   multer().none(),
   validateGroup(),
   handleValidationError(400),

--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -24,7 +24,7 @@ block content
                 span.icon
                   i.fas.fa-copy
                 span &nbsp;Másolás
-              if isOwner
+              if isOwner || isAdmin
                 a.dropdown-item(href=`/groups/${group.id}/edit`)
                   span.icon
                     i.fas.fa-edit


### PR DESCRIPTION
Closes #446 

### What's new:
* What admin can do with ANY group in the app:
  * See Edit and Delete buttons on group show page
  * Open Edit page with that button
  * Delete group
  * Update group with sending form on group edit page
* Overwrite isGroupOwner middleware to isGroupOwnerOrAdmin
* Use deprecation warning on old function (do we want to delete it completely?)