### PR TITLE
Fix createdAt in add_groups seed

### DIFF
--- a/seeds/02_add_groups.ts
+++ b/seeds/02_add_groups.ts
@@ -36,7 +36,7 @@ export async function seed(knex: Knex): Promise<void> {
         endDate: (new Date( Date.now() + startSeed * (j + 1) + maxTwoHours )),
         room: i + startingFloor,
         doNotDisturb: (i * groupsPerFloor + j) % 16 == 1,
-        createdAt: (new Date()).toDateString(),
+        createdAt: new Date(),
         ownerId
       }
       console.log('\x1b[33m%s\x1b[0m', 


### PR DESCRIPTION
Add_group seed didn't use correct form of a datetime timestamp, and used only date part of timestamp (because of a wild toDateString method).