### PR TITLE
Bump/462 fullcalendar

### DIFF
--- a/public/css/tailwind.css
+++ b/public/css/tailwind.css
@@ -45,20 +45,20 @@
     @apply dark:bg-gray-800 dark:text-gray-50;
   }
 
-  .fc-unthemed td.fc-today {
+  .fc-theme-standard td.fc-today {
     @apply bg-opacity-75 dark:bg-blue-900;
   }
 
-  .fc-unthemed th,
-  .fc-unthemed td,
-  .fc-unthemed thead,
-  .fc-unthemed tbody,
-  .fc-unthemed .fc-divider,
-  .fc-unthemed .fc-row,
-  .fc-unthemed .fc-content,
-  .fc-unthemed .fc-popover,
-  .fc-unthemed .fc-list-view,
-  .fc-unthemed .fc-list-heading td {
+  .fc-theme-standard th,
+  .fc-theme-standard td,
+  .fc-theme-standard thead,
+  .fc-theme-standard tbody,
+  .fc-theme-standard .fc-divider,
+  .fc-theme-standard .fc-row,
+  .fc-theme-standard .fc-content,
+  .fc-theme-standard .fc-popover,
+  .fc-theme-standard .fc-list-view,
+  .fc-theme-standard .fc-list-heading td {
     @apply border-gray-500;
   }
 }

--- a/public/js/room/calendar.js
+++ b/public/js/room/calendar.js
@@ -1,5 +1,4 @@
 const commonCalendarOptions = {
-  //plugins: ['interaction', 'timegrid', 'daygrid'],
   views: {
     timeGridOneDay: {
       type: 'timeGrid',
@@ -19,6 +18,7 @@ const commonCalendarOptions = {
     week: 'hét',
   },
   nowIndicator: true,
+  firstDay: 1,
   locale: 'hu',
   selectable: true,
   eventClick: (calEvent) =>

--- a/public/js/room/calendar.js
+++ b/public/js/room/calendar.js
@@ -74,7 +74,7 @@ function generateMobileCalendar(data, calendarEl, room) {
         }
       }
     },
-    footer: {
+    footerToolbar: {
       center: 'prevWeek,prev,today,next,nextWeek'
     },
     titleFormat: {

--- a/public/js/room/calendar.js
+++ b/public/js/room/calendar.js
@@ -1,5 +1,5 @@
 const commonCalendarOptions = {
-  plugins: ['interaction', 'timeGrid', 'dayGrid'],
+  //plugins: ['interaction', 'timegrid', 'daygrid'],
   views: {
     timeGridOneDay: {
       type: 'timeGrid',
@@ -28,12 +28,12 @@ const commonCalendarOptions = {
 function generateWebCalendar(data, calendarEl, room) {
   const calendar = new FullCalendar.Calendar(calendarEl, {
     ...commonCalendarOptions,
-    header: {
+    headerToolbar: {
       left: 'prev,next today',
       center: 'title',
       right: 'timeGridOneDay,timeGridWeek,dayGridMonth',
     },
-    defaultView: 'timeGridWeek',
+    initialView: 'timeGridWeek',
     events: data,
     select: (info) => {
       if (info.view.type === 'dayGridMonth') {
@@ -50,12 +50,12 @@ function generateWebCalendar(data, calendarEl, room) {
 function generateMobileCalendar(data, calendarEl, room) {
   const calendar = new FullCalendar.Calendar(calendarEl, {
     ...commonCalendarOptions,
-    header: {
+    headerToolbar: {
       left: 'title',
       center: '',
       right: 'timeGridOneDay,dayGridMonth'
     },
-    defaultView: 'timeGridOneDay',
+    initialView: 'timeGridOneDay',
     customButtons: {
       prevWeek: {
         text: '-7',

--- a/views/room/calendar.pug
+++ b/views/room/calendar.pug
@@ -1,10 +1,6 @@
 extend ../layouts/main
 
 block styles
-  //link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.3.1/main.min.css")
-  //link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.3.0/main.min.css")
-  //link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.3.0/main.min.css")
-
   link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/fullcalendar@5.6.0/main.min.css")
 
 block content
@@ -13,16 +9,10 @@ block content
       each floor in ROOMS
         option(value=`${floor}` selected=floor==room ? 'selected' : false)
           a(href=`/rooms/${floor}`)= floor + ". emelet"
-  div(class='flex flex-col items-center justify-center')
-    div(class='max-w-6xl p-3 mx-4 my-4 sm:p-6 rounded-2xl bg-default shadow-full')
+  div(class='max-w-6xl p-3 mx-auto my-4 sm:p-6 rounded-2xl bg-default shadow-full')
       #calendar
 
 block scripts
-  //script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.3.0/main.js')
-  //script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.3.0/main.min.js')
-  //script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.3.0/main.min.js')
-  //script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@4.3.0/main.min.js')
-
   script(src='https://cdn.jsdelivr.net/npm/fullcalendar@5.6.0/main.min.js')
 
   script(src='/js/room/calendar.js')

--- a/views/room/calendar.pug
+++ b/views/room/calendar.pug
@@ -9,7 +9,7 @@ block content
       each floor in ROOMS
         option(value=`${floor}` selected=floor==room ? 'selected' : false)
           a(href=`/rooms/${floor}`)= floor + ". emelet"
-  div(class='max-w-6xl p-3 mx-auto my-4 sm:p-6 rounded-2xl bg-default shadow-full')
+  div(class='max-w-6xl p-3 mx-4 sm:mx-auto my-4 sm:p-6 rounded-2xl bg-default shadow-full')
       #calendar
 
 block scripts

--- a/views/room/calendar.pug
+++ b/views/room/calendar.pug
@@ -1,9 +1,11 @@
 extend ../layouts/main
 
 block styles
-  link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.3.1/main.min.css")
-  link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.3.0/main.min.css")
-  link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.3.0/main.min.css")
+  //link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.3.1/main.min.css")
+  //link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.3.0/main.min.css")
+  //link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.3.0/main.min.css")
+
+  link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/fullcalendar@5.6.0/main.min.css")
 
 block content
   div(class="ml-4")
@@ -16,8 +18,11 @@ block content
       #calendar
 
 block scripts
-  script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.3.0/main.js')
-  script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.3.0/main.min.js')
-  script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.3.0/main.min.js')
-  script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@4.3.0/main.min.js')
+  //script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.3.0/main.js')
+  //script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.3.0/main.min.js')
+  //script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.3.0/main.min.js')
+  //script(src='https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@4.3.0/main.min.js')
+
+  script(src='https://cdn.jsdelivr.net/npm/fullcalendar@5.6.0/main.min.js')
+
   script(src='/js/room/calendar.js')


### PR DESCRIPTION
Updated FullCalendar to 5.6.0

- FullCalendar no longer supports importing individual plugins with CDN, so now we're importing the whole standard bundle.
- A few options and classnames have been renamed

I changed the styling around the calendar a bit to achieve the same look it had before the update, I'm not sure this was the best way, but I'm really not good at CSS. Also, disabled, vertical scrollbars now show up next to the header, not sure if that's a problem.

Finally, I changed first day of the week to Monday. This is unrelated to the update, but I thought it would be more appropriate.

Closes #462