### PR TITLE
Kick a member from group and general purpose modal

### DIFF
--- a/public/js/group/show.js
+++ b/public/js/group/show.js
@@ -1,14 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const deleteGroup = (id) => {
-  if (confirm('Biztosan törlöd?')) {
-    fetch(`/groups/${id}`, { method: 'DELETE' })
-      .then((res) => {
-        if (res.status === 204) {
-          location.href = '/groups'
-        }
-      })
-      .catch((err) => console.error(err))
-  }
+  fetch(`/groups/${id}`, { method: 'DELETE' })
+    .then((res) => {
+      if (res.status === 204) {
+        location.href = '/groups'
+      }
+    })
+    .catch((err) => console.error(err))
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/public/js/modal.js
+++ b/public/js/modal.js
@@ -1,0 +1,37 @@
+// ommitted parameters won't be changed
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function toggleModal(newAction, newTitle, newDesc, newButtonText, newIsActionFunction = 0) {
+  const title = document.getElementById('modal-title')
+  const description = document.getElementById('modal-desc')
+  const submitButton = document.getElementById('submit-button')
+  const funcButton = document.getElementById('func-button')
+  const form = document.getElementById('modal-form')
+
+  if (newTitle) {
+    title.innerHTML = newTitle
+  }
+  if (newDesc) {
+    description.innerHTML = newDesc
+  }
+  if (newButtonText) {
+    submitButton.innerHTML = newButtonText
+    funcButton.innerHTML = newButtonText
+  }
+  if (newAction) {
+    form.action = newAction
+    funcButton.setAttribute( 'onClick', `javascript: ${newAction}`)
+  }
+
+  if (newIsActionFunction !== 0) {
+    if (newIsActionFunction) {
+      form.classList.add('hidden')
+      funcButton.classList.remove('hidden')
+    } else {
+      funcButton.classList.add('hidden')
+      form.classList.remove('hidden')
+    }
+  }
+
+  const modal = document.querySelector('.modal')
+  modal.classList.toggle('hidden')
+}

--- a/public/js/modal.js
+++ b/public/js/modal.js
@@ -1,6 +1,6 @@
-// ommitted parameters won't be changed
+// omitted parameters won't be changed
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function toggleModal(newAction, newTitle, newDesc, newButtonText, newIsActionFunction = 0) {
+function toggleModal(newAction, newTitle, newDesc, newButtonText, newIsActionFunction = undefined) {
   const title = document.getElementById('modal-title')
   const description = document.getElementById('modal-desc')
   const submitButton = document.getElementById('submit-button')
@@ -19,10 +19,10 @@ function toggleModal(newAction, newTitle, newDesc, newButtonText, newIsActionFun
   }
   if (newAction) {
     form.action = newAction
-    funcButton.setAttribute( 'onClick', `javascript: ${newAction}`)
+    funcButton.setAttribute( 'onClick', `javascript: toggleModal(); ${newAction};`)
   }
 
-  if (newIsActionFunction !== 0) {
+  if (typeof newIsActionFunction !== 'undefined') {
     if (newIsActionFunction) {
       form.classList.add('hidden')
       funcButton.classList.remove('hidden')
@@ -32,6 +32,5 @@ function toggleModal(newAction, newTitle, newDesc, newButtonText, newIsActionFun
     }
   }
 
-  const modal = document.querySelector('.modal')
-  modal.classList.toggle('hidden')
+  document.querySelector('.modal').classList.toggle('hidden')
 }

--- a/public/js/ticket.js
+++ b/public/js/ticket.js
@@ -1,37 +1,35 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function deleteTicket(id, own) {
   const url = `/tickets/${own ? 'own/' : ''}${id}`
-  if (confirm('Biztosan törlöd?')) {
-    fetch(url, { method: 'DELETE' })
-      .then(async res => {
-        switch(res.status) {
-        case 204:
-          const ticket = document.getElementById(`ticket-${id}`)
-          const container = ticket.parentNode
-          container.removeChild(ticket)
-          displayMessage('Hibajegy sikeresen törölve', 'success')
-
-          if (container.childElementCount == 0){
-            const text = document.createElement('p')
-            text.classList.add('ml-6')
-            text.innerHTML = own ? 'Nincsen hibajegyed' : 'Nincsenek hibajegyek'
-            container.appendChild(text)
-          }
-          break
-        case 401:
-          displayMessage(UNAUTHORIZED_MESSAGE)
-          break
-        case 403:
-          displayMessage(FORBIDDEN_MESSAGE)
-          break
-        case 404:
-          data = await res.json()
-          displayMessage(data.message)
-          break
+  toggleModal()
+  fetch(url, { method: 'DELETE' })
+    .then(async res => {
+      switch(res.status) {
+      case 204:
+        const ticket = document.getElementById(`ticket-${id}`)
+        const container = ticket.parentNode
+        container.removeChild(ticket)
+        displayMessage('Hibajegy sikeresen törölve', 'success')
+        if (container.childElementCount == 0){
+          const text = document.createElement('p')
+          text.classList.add('ml-6')
+          text.innerHTML = own ? 'Nincsen hibajegyed' : 'Nincsenek hibajegyek'
+          container.appendChild(text)
         }
-      })
-      .catch(err => displayMessage(err))
-  }
+        break
+      case 401:
+        displayMessage(UNAUTHORIZED_MESSAGE)
+        break
+      case 403:
+        displayMessage(FORBIDDEN_MESSAGE)
+        break
+      case 404:
+        data = await res.json()
+        displayMessage(data.message)
+        break
+      }
+    })
+    .catch(err => displayMessage(err))
 }
 
 function validateTicket(data) {

--- a/public/js/ticket.js
+++ b/public/js/ticket.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function deleteTicket(id, own) {
   const url = `/tickets/${own ? 'own/' : ''}${id}`
-  toggleModal()
+  
   fetch(url, { method: 'DELETE' })
     .then(async res => {
       switch(res.status) {

--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -41,13 +41,8 @@ asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   if (!kickableUser) {
     res.redirect('/not-found')
   } else {
-    let inGroup = false
     const usersInGroup = await Group.relatedQuery('users').for(req.group.id)
-    usersInGroup.map(user => {
-      if (user.id === kickableUser.id) {
-        inGroup = true
-      }
-    })
+    const inGroup = usersInGroup.find(user => user.id === kickableUser.id)
     if (!inGroup) {
       res.redirect('/not-found')
     } else {

--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -39,11 +39,7 @@ asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
     .findOne({ id: parseInt(req.params.userid) })
 
   if (!kickableUser) {
-    res.status(400).json(
-      {
-        errors: [{msg: 'Nem létezik ilyen felhasználó!'}]
-      }
-    )
+    res.redirect('/not-found')
   } else {
     let inGroup = false
     const usersInGroup = await Group.relatedQuery('users').for(req.group.id)
@@ -52,13 +48,8 @@ asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
         inGroup = true
       }
     })
-
     if (!inGroup) {
-      res.status(400).json(
-        {
-          errors: [{msg: 'Ez a felhasználó nem tagja ennek a csoportnak!'}]
-        }
-      )
+      res.redirect('/not-found')
     } else {
       next()
     }

--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -35,19 +35,12 @@ export const leaveGroup = asyncWrapper(async (req: Request, res: Response, next:
 
 export const isMemberInGroup = 
 asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
-  const kickableUser = await User.query()
-    .findOne({ id: parseInt(req.params.userid) })
-
-  if (!kickableUser) {
-    res.redirect('/not-found')
+  const kickableUser = await Group.relatedQuery('users').for(req.group.id)
+    .findOne({ userId: parseInt(req.params.userid) })
+  if (kickableUser) {
+    next()
   } else {
-    const usersInGroup = await Group.relatedQuery('users').for(req.group.id)
-    const inGroup = usersInGroup.find(user => user.id === kickableUser.id)
-    if (!inGroup) {
-      res.redirect('/not-found')
-    } else {
-      next()
-    }
+    res.redirect('/not-found')
   }
 })
 

--- a/src/components/groups/group.routes.ts
+++ b/src/components/groups/group.routes.ts
@@ -14,6 +14,8 @@ import { RoleType, User } from '../users/user'
 import {
   joinGroup,
   leaveGroup,
+  isMemberInGroup,
+  kickMember,
   createICSEvent,
   checkConflicts,
   validateGroup,
@@ -83,6 +85,14 @@ router.post('/:id/leave',
   getGroup,
   leaveGroup,
   (req, res) => res.redirect('/groups')
+)
+router.post('/:id/kick/:userid',
+  isAuthenticated,
+  getGroup,
+  isGroupOwnerOrAdmin,
+  isMemberInGroup,
+  kickMember,
+  (req, res) => res.redirect(`/groups/${req.params.id}`)
 )
 
 router.delete('/:id',

--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -1,5 +1,7 @@
 extends ../layouts/main
 
+include ../modalTemplate.pug
+
 block content
   - const [startDate, startTime] = format(group.startDate, DATE_FORMAT).split(' ')
   - const [endDate, endTime] = format(group.endDate, DATE_FORMAT).split(' ')
@@ -9,8 +11,7 @@ block content
       form(action=`/groups/${group.id}/join`, method="post")
         button(type="submit" class='text-xl btn btn-primary animate-hover') Csatlakozás
     else if !isOwner && joined
-      form(action=`/groups/${group.id}/leave`, method="post")
-        button(type="submit" class='text-xl bg-yellow-400 btn btn-primary animate-hover dark:text-black hover:bg-yellow-500') Kilépés
+      button(type="button" class='text-xl bg-yellow-400 btn btn-primary animate-hover dark:text-black hover:bg-yellow-500' onClick=`toggleModal('/groups/${group.id}/leave', 'Biztosan ki akarsz lépni?', 'Biztosan ki akarsz lépni a(z) ${group.name} csoportból?', 'Kilépés')`) Kilépés
   div(class='flex flex-col px-8 pt-6 pb-8 mx-6 sm:px-16 lg:flex-row lg:justify-between rounded-2xl bg-default md:mx-16 lg:mx-24 xl:mx-40 shadow-full')
     div(class='mr-4 space-y-4')
       div
@@ -119,6 +120,11 @@ block content
             a(href=`/users/${user.id}` class='lg:whitespace-no-wrap hover:text-blue-500')= user.name
             if user.id === group.ownerId
               span(class='px-3 py-1 text-sm text-white bg-purple-500 rounded-full') Szervező
+            else if isOwner || isAdmin
+              button(type='button' class='px-3 py-1 text-sm text-white btn btn-primary animate-hover cursor-pointer' onClick=`toggleModal('/groups/${group.id}/kick/${user.id}', 'Biztosan ki akarod rúgni ${user.name}-t?', 'Biztosan ki akarod rúgni ${user.name}-t? Ezt később nem tudod visszavonni!', 'Kirúgás')`) Kirúgás
+
+  +modalTemplate()
+
 
 block scripts
   script(src='/js/group/show.js')

--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -11,7 +11,12 @@ block content
       form(action=`/groups/${group.id}/join`, method="post")
         button(type="submit" class='text-xl btn btn-primary animate-hover') Csatlakozás
     else if !isOwner && joined
-      button(type="button" class='text-xl bg-yellow-400 btn btn-primary animate-hover dark:text-black hover:bg-yellow-500' onClick=`toggleModal('/groups/${group.id}/leave', 'Biztosan ki akarsz lépni?', 'Biztosan ki akarsz lépni a(z) ${group.name} csoportból?', 'Kilépés')`) Kilépés
+      button(type="button" class='text-xl bg-yellow-400 btn btn-primary animate-hover dark:text-black hover:bg-yellow-500' onClick=`toggleModal(
+        '/groups/${group.id}/leave',
+        'Biztosan ki akarsz lépni?',
+        'Biztosan ki akarsz lépni a(z) ${group.name} csoportból?',
+        'Kilépés',
+        false)`) Kilépés
   div(class='flex flex-col px-8 pt-6 pb-8 mx-6 sm:px-16 lg:flex-row lg:justify-between rounded-2xl bg-default md:mx-16 lg:mx-24 xl:mx-40 shadow-full')
     div(class='mr-4 space-y-4')
       div
@@ -52,7 +57,13 @@ block content
                     path(fill-rule='evenodd' d='M2 6a2 2 0 012-2h4a1 1 0 010 2H4v10h10v-4a1 1 0 112 0v4a2 2 0 01-2 2H4a2 2 0 01-2-2V6z' clip-rule='evenodd')
                   span &nbsp;Módosítás
                 hr.dropdown-divider
-                a(onclick=`deleteGroup(${group.id})` class='flex flex-row items-center cursor-pointer hover:text-red-500 animate-hover')
+                a(onclick=`toggleModal(
+                  'deleteGroup(${group.id})',
+                  'Biztosan törlöd ezt a csoportot?',
+                  'Biztosan törlöd a(z) ${group.name} csoportot? Ezt később nem tudod visszavonni!',
+                  'Törlés',
+                  true)`
+                  class='flex flex-row items-center cursor-pointer hover:text-red-500 animate-hover' @click='open = false')
                   //- Heroicon name: trash
                   svg(xmlns='http://www.w3.org/2000/svg' alt="Törlés" aria-label="Törlés" viewbox='0 0 20 20' fill='currentColor' class='w-5 h-5')
                     path(fill-rule='evenodd' d='M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z' clip-rule='evenodd')
@@ -121,7 +132,12 @@ block content
             if user.id === group.ownerId
               span(class='px-3 py-1 text-sm text-white bg-purple-500 rounded-full') Szervező
             else if isOwner || isAdmin
-              button(type='button' class='px-3 py-1 text-sm text-white btn btn-primary animate-hover cursor-pointer' onClick=`toggleModal('/groups/${group.id}/kick/${user.id}', 'Biztosan ki akarod rúgni ${user.name}-t?', 'Biztosan ki akarod rúgni ${user.name}-t? Ezt később nem tudod visszavonni!', 'Kirúgás')`) Kirúgás
+              button(type='button' class='px-3 py-1 text-sm text-white btn btn-primary animate-hover cursor-pointer' onClick=`toggleModal(
+                '/groups/${group.id}/kick/${user.id}',
+                'Biztosan ki akarod rúgni ${user.name}-t?',
+                'Biztosan ki akarod rúgni ${user.name}-t? Ezt később nem tudod visszavonni!',
+                'Kirúgás',
+                false)`) Kirúgás
 
   +modalTemplate()
 

--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -127,7 +127,7 @@ block content
       h2(class='mb-3 text-3xl uppercase') Résztvevők
       div(class='flex flex-col items-start space-y-2 text-xl')
         each user in group.users
-          div(class='flex flex-row items-center ml-6 space-x-2')
+          div(class='w-full flex flex-row justify-between items-center ml-6 space-x-2')
             a(href=`/users/${user.id}` class='lg:whitespace-no-wrap hover:text-blue-500')= user.name
             if user.id === group.ownerId
               span(class='px-3 py-1 text-sm text-white bg-purple-500 rounded-full') Szervező

--- a/views/modalTemplate.pug
+++ b/views/modalTemplate.pug
@@ -1,0 +1,47 @@
+mixin modalTemplate(route, title, desc, buttonText)
+  div(class="modal hidden fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true")
+    div(class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0")
+      //- modal overlay
+      div(class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick='toggleModal()' aria-hidden="true")
+
+      span(class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true") &#8203;
+      //- modal
+      div(class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full")
+        div(class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4")
+          div(class="sm:flex sm:items-start")
+            div(class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10")
+              //-- Heroicon name: outline/exclamation
+              svg(class="h-6 w-6 text-red-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true")
+                path(stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" )
+            div(class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left")
+              h3(class="text-lg leading-6 font-medium text-gray-900" id="modal-title")= title
+              div(class="mt-2")
+                p(class="text-sm text-gray-500" id='modal-desc')= desc
+        div(class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse")
+          form(action=route, method="post" id='modal-form')
+            button(type="submit" id='submit-button' class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 btn btn-primary text-base font-medium text-white animate-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400 sm:ml-3 sm:w-auto sm:text-sm")= buttonText
+          button(type="button" onClick='toggleModal()' class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm") Mégse
+  
+  script.
+    function toggleModal(newRoute, newTitle, newDesc, newButtonText) {
+      const title = document.getElementById('modal-title')
+      const description = document.getElementById('modal-desc')
+      const button = document.getElementById('submit-button')
+      const form = document.getElementById('modal-form')
+
+      if (newTitle) {
+        title.innerHTML = newTitle
+      }
+      if (newDesc) {
+        description.innerHTML = newDesc
+      }
+      if (newButtonText) {
+        button.innerHTML = newButtonText
+      }
+      if (newRoute) {
+        form.action = newRoute
+      }
+
+      const modal = document.querySelector('.modal')
+      modal.classList.toggle('hidden')
+    }

--- a/views/modalTemplate.pug
+++ b/views/modalTemplate.pug
@@ -5,26 +5,26 @@ mixin modalTemplate(action, title, desc, buttonText, isActionFunction)
   div(class="modal hidden fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true")
     div(class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0")
       //- modal overlay
-      div(class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" onClick='toggleModal()' aria-hidden="true")
+      div(class="fixed inset-0 bg-gray-500 dark:bg-gray-800 bg-opacity-75 dark:bg-opacity-75 transition-opacity" onClick='toggleModal()' aria-hidden="true")
 
       span(class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true") &#8203;
       //- modal
       div(class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full")
-        div(class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4")
+        div(class="bg-default px-4 pt-5 pb-4 sm:p-6 sm:pb-4")
           div(class="sm:flex sm:items-start")
             div(class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10")
               //-- Heroicon name: outline/exclamation
-              svg(class="h-6 w-6 text-red-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true")
+              svg(class="h-6 w-6 text-red-400 dark:text" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true")
                 path(stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" )
             div(class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left")
-              h3(class="text-lg leading-6 font-medium text-gray-900" id="modal-title")= title
+              h3(class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100" id="modal-title")= title
               div(class="mt-2")
-                p(class="text-sm text-gray-500" id='modal-desc')= desc
-        div(class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse")
-          form(action=action, method="post" id='modal-form' class=`${isActionFunction ? 'hidden':''}`)
-            button(type="submit" id='submit-button' class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 btn btn-primary text-base font-medium text-white animate-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400 sm:ml-3 sm:w-auto sm:text-sm")= buttonText
-          button(type="button" id='func-button' onClick=`toggleModal();${action};` class=`${!isActionFunction ? 'hidden' : ''} w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 btn btn-primary text-base font-medium text-white animate-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400 sm:ml-3 sm:w-auto sm:text-sm`)= buttonText
-          button(type="button" onClick='toggleModal()' class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm") Mégse
+                p(class="text-sm text-gray-500 dark:text-gray-100" id='modal-desc')= desc
+        div(class="bg-default px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse -mx-1")
+          form(action=action, method="post" id='modal-form' class=`${isActionFunction ? 'hidden':''} mx-1`)
+            button(type="submit" id='submit-button' class="mx-1 w-full sm:w-auto text-lg inline-flex justify-center px-4 py-2 btn btn-primary text-white ")= buttonText
+          button(type="button" id='func-button' onClick=`toggleModal();${action};` class=`${!isActionFunction ? 'hidden' : ''} mx-2 w-full sm:w-auto text-lg inline-flex justify-center px-4 py-2 btn btn-primary text-white`)= buttonText
+          button(type="button" onClick='toggleModal()' class="mt-2 mx-1 w-full inline-flex justify-center px-4 py-2 text-lg btn bg-gray-200 animate-hover dark:bg-gray-600 dark:hover:bg-gray-700 dark:text-white sm:mt-0 sm:ml-3 sm:w-auto") Mégse
   
   script(src='/js/modal.js')
   

--- a/views/modalTemplate.pug
+++ b/views/modalTemplate.pug
@@ -23,8 +23,8 @@ mixin modalTemplate(action, title, desc, buttonText, isActionFunction)
         div(class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse")
           form(action=action, method="post" id='modal-form' class=`${isActionFunction ? 'hidden':''}`)
             button(type="submit" id='submit-button' class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 btn btn-primary text-base font-medium text-white animate-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400 sm:ml-3 sm:w-auto sm:text-sm")= buttonText
-          button(type="button" id='func-button' onClick=action class=`${!isActionFunction ? 'hidden' : ''} w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 btn btn-primary text-base font-medium text-white animate-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400 sm:ml-3 sm:w-auto sm:text-sm`)= buttonText
+          button(type="button" id='func-button' onClick=`toggleModal();${action};` class=`${!isActionFunction ? 'hidden' : ''} w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 btn btn-primary text-base font-medium text-white animate-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400 sm:ml-3 sm:w-auto sm:text-sm`)= buttonText
           button(type="button" onClick='toggleModal()' class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm") Mégse
   
-  script(src='../public/js/modal.js')
+  script(src='/js/modal.js')
   

--- a/views/modalTemplate.pug
+++ b/views/modalTemplate.pug
@@ -26,40 +26,5 @@ mixin modalTemplate(action, title, desc, buttonText, isActionFunction)
           button(type="button" id='func-button' onClick=action class=`${!isActionFunction ? 'hidden' : ''} w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 btn btn-primary text-base font-medium text-white animate-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400 sm:ml-3 sm:w-auto sm:text-sm`)= buttonText
           button(type="button" onClick='toggleModal()' class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm") Mégse
   
-  //- ommitted parameters won't be changed
-  script.
-    function toggleModal(newAction, newTitle, newDesc, newButtonText, newIsActionFunction = 0) {
-      const title = document.getElementById('modal-title')
-      const description = document.getElementById('modal-desc')
-      const submitButton = document.getElementById('submit-button')
-      const funcButton = document.getElementById('func-button')
-      const form = document.getElementById('modal-form')
-
-      if (newTitle) {
-        title.innerHTML = newTitle
-      }
-      if (newDesc) {
-        description.innerHTML = newDesc
-      }
-      if (newButtonText) {
-        submitButton.innerHTML = newButtonText
-        funcButton.innerHTML = newButtonText
-      }
-      if (newAction) {
-        form.action = newAction
-        funcButton.setAttribute( 'onClick', `javascript: ${newAction}`)
-      }
-
-      if (newIsActionFunction !== 0) {
-        if (newIsActionFunction) {
-          form.classList.add('hidden')
-          funcButton.classList.remove('hidden')
-        } else {
-          funcButton.classList.add('hidden')
-          form.classList.remove('hidden')
-        }
-      }
-
-      const modal = document.querySelector('.modal')
-      modal.classList.toggle('hidden')
-    }
+  script(src='../public/js/modal.js')
+  

--- a/views/modalTemplate.pug
+++ b/views/modalTemplate.pug
@@ -5,7 +5,7 @@ mixin modalTemplate(action, title, desc, buttonText, isActionFunction)
   div(class="modal hidden fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true")
     div(class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0")
       //- modal overlay
-      div(class="fixed inset-0 bg-gray-500 dark:bg-gray-800 bg-opacity-75 dark:bg-opacity-75 transition-opacity" onClick='toggleModal()' aria-hidden="true")
+      div(class="fixed inset-0 bg-gray-500 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-75 transition-opacity" onClick='toggleModal()' aria-hidden="true")
 
       span(class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true") &#8203;
       //- modal
@@ -24,7 +24,7 @@ mixin modalTemplate(action, title, desc, buttonText, isActionFunction)
           form(action=action, method="post" id='modal-form' class=`${isActionFunction ? 'hidden':''} mx-1`)
             button(type="submit" id='submit-button' class="mx-1 w-full sm:w-auto text-lg inline-flex justify-center px-4 py-2 btn btn-primary text-white ")= buttonText
           button(type="button" id='func-button' onClick=`toggleModal();${action};` class=`${!isActionFunction ? 'hidden' : ''} mx-2 w-full sm:w-auto text-lg inline-flex justify-center px-4 py-2 btn btn-primary text-white`)= buttonText
-          button(type="button" onClick='toggleModal()' class="mt-2 mx-1 w-full inline-flex justify-center px-4 py-2 text-lg btn bg-gray-200 animate-hover dark:bg-gray-600 dark:hover:bg-gray-700 dark:text-white sm:mt-0 sm:ml-3 sm:w-auto") Mégse
+          button(type="button" onClick='toggleModal()' class="mt-2 mx-1 w-full inline-flex justify-center px-4 py-2 text-lg btn bg-gray-200 hover:bg-gray-300 animate-hover dark:bg-gray-600 dark:hover:bg-gray-700 dark:text-white sm:mt-0 sm:ml-3 sm:w-auto") Mégse
   
   script(src='/js/modal.js')
   

--- a/views/modalTemplate.pug
+++ b/views/modalTemplate.pug
@@ -1,4 +1,7 @@
-mixin modalTemplate(route, title, desc, buttonText)
+//- action: what should happen when the user confirms their action with the modal
+//- if isActionFunction is true, then action should be a function (as a string) that the button's onClick method can call
+//- otherwise action should be a route to which a form will send a post request
+mixin modalTemplate(action, title, desc, buttonText, isActionFunction)
   div(class="modal hidden fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true")
     div(class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0")
       //- modal overlay
@@ -18,15 +21,18 @@ mixin modalTemplate(route, title, desc, buttonText)
               div(class="mt-2")
                 p(class="text-sm text-gray-500" id='modal-desc')= desc
         div(class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse")
-          form(action=route, method="post" id='modal-form')
+          form(action=action, method="post" id='modal-form' class=`${isActionFunction ? 'hidden':''}`)
             button(type="submit" id='submit-button' class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 btn btn-primary text-base font-medium text-white animate-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400 sm:ml-3 sm:w-auto sm:text-sm")= buttonText
+          button(type="button" id='func-button' onClick=action class=`${!isActionFunction ? 'hidden' : ''} w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 btn btn-primary text-base font-medium text-white animate-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-400 sm:ml-3 sm:w-auto sm:text-sm`)= buttonText
           button(type="button" onClick='toggleModal()' class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm") Mégse
   
+  //- ommitted parameters won't be changed
   script.
-    function toggleModal(newRoute, newTitle, newDesc, newButtonText) {
+    function toggleModal(newAction, newTitle, newDesc, newButtonText, newIsActionFunction = 0) {
       const title = document.getElementById('modal-title')
       const description = document.getElementById('modal-desc')
-      const button = document.getElementById('submit-button')
+      const submitButton = document.getElementById('submit-button')
+      const funcButton = document.getElementById('func-button')
       const form = document.getElementById('modal-form')
 
       if (newTitle) {
@@ -36,10 +42,22 @@ mixin modalTemplate(route, title, desc, buttonText)
         description.innerHTML = newDesc
       }
       if (newButtonText) {
-        button.innerHTML = newButtonText
+        submitButton.innerHTML = newButtonText
+        funcButton.innerHTML = newButtonText
       }
-      if (newRoute) {
-        form.action = newRoute
+      if (newAction) {
+        form.action = newAction
+        funcButton.setAttribute( 'onClick', `javascript: ${newAction}`)
+      }
+
+      if (newIsActionFunction !== 0) {
+        if (newIsActionFunction) {
+          form.classList.add('hidden')
+          funcButton.classList.remove('hidden')
+        } else {
+          funcButton.classList.add('hidden')
+          form.classList.remove('hidden')
+        }
       }
 
       const modal = document.querySelector('.modal')

--- a/views/ticket/index.pug
+++ b/views/ticket/index.pug
@@ -1,6 +1,7 @@
 extends ../layouts/main
 
 include ticketTemplate.pug
+include ../modalTemplate.pug
 
 block content
   div(class='flex flex-row items-center space-x-4')
@@ -20,6 +21,12 @@ block content
       +ticketTemplate(ticket, format, DATE_FORMAT, STATUSES, false)
     else
       p(class="ml-6") Nincsenek hibajegyek
+
+  +modalTemplate('',
+    'Biztosan törlöd ezt a hibajegyet?',
+    'Ezt később nem tudod visszavonni!',
+    'Törlés',
+    true)
 
 block scripts
   script(src='/js/ticket.js')

--- a/views/ticket/ticketTemplate.pug
+++ b/views/ticket/ticketTemplate.pug
@@ -10,7 +10,7 @@ mixin ticketTemplate(ticket, format, DATE_FORMAT, STATUSES, own)
             h2(class='text-2xl sm:xt-3xl') #{ticket.roomNumber}. emelet
             span(id=`ticket-label-${ticket.id}` class='px-2 py-1 text-sm font-bold text-gray-600 border-2 border-gray-500 rounded-lg dark:text-gray-400') #{STATUSES.get(ticket.status) ? STATUSES.get(ticket.status): 'Ismeretlen'}
         if (user.role === "ADMIN" || user.role === "TICKET_ADMIN" || user.id == ticket.userId)
-          a(type="button", onclick=`deleteTicket(${ticket.id}, ${own})`)
+          a(type="button", onclick=`toggleModal('deleteTicket(${ticket.id}, ${own})')`)
             svg(xmlns='http://www.w3.org/2000/svg' alt="Törlés" aria-label="Törlés" fill='none' viewbox='0 0 24 24' stroke='currentColor' class='w-6 h-6 text-red-500 cursor-pointer')
               path(stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16')
       div(class='ml-8 text-xl break-words') !{ticket.description}


### PR DESCRIPTION
- Admins and group owners can now kick (non-owner) members from a group.
- They must confirm this action on a custom (Tailwind) modal
- This modal has a template that can be used elsewhere in the code
- Even if this modal is used for multiple things on the same page, there will always be only one modal in the DOM
- Added this modal to the following actions: leaving a group, deleting a group, deleting a ticket.
Closes #309 