### PR TITLE
Fixed navbar on tablets

### DIFF
--- a/views/partials/header.pug
+++ b/views/partials/header.pug
@@ -27,7 +27,7 @@ header(x-data="{ open: false }")
               x-transition:leave-start="opacity-100"
               x-transition:leave-end="opacity-0")
     div(class='hidden md:block')
-      div(class='flex flex-row items-center justify-around space-x-10')
+      div(class='flex flex-row items-center justify-around space-x-7')
         a(onclick='changeTheme()' aria-label="Sötét mód váltása" class='cursor-pointer nav-link')
           //- Heroicon name: sun
           svg(xmlns='http://www.w3.org/2000/svg' alt="Sötét mód" aria-label="Sötét mód" fill='none' viewbox='0 0 24 24' stroke='currentColor' class='w-6 h-6')

--- a/views/partials/header.pug
+++ b/views/partials/header.pug
@@ -27,7 +27,7 @@ header(x-data="{ open: false }")
               x-transition:leave-start="opacity-100"
               x-transition:leave-end="opacity-0")
     div(class='hidden md:block')
-      div(class='flex flex-row items-center justify-around space-x-7')
+      div(class='flex flex-row items-center justify-around space-x-7 lg:space-x-10')
         a(onclick='changeTheme()' aria-label="Sötét mód váltása" class='cursor-pointer nav-link')
           //- Heroicon name: sun
           svg(xmlns='http://www.w3.org/2000/svg' alt="Sötét mód" aria-label="Sötét mód" fill='none' viewbox='0 0 24 24' stroke='currentColor' class='w-6 h-6')


### PR DESCRIPTION
Changed the margin between navbar elements to 28px (from 40px) on medium screens (tablets). This way there's still enough space between the dark mode toggle button and the title.
Closes #701 