### PR TITLE
Store error/success messages in cookies

### DIFF
--- a/public/js/group/create.js
+++ b/public/js/group/create.js
@@ -13,9 +13,10 @@ const validateGroup = (data) => {
   return errors
 }
 
-const handleResponse = async (res) => {
+const handleResponse = async (res, edited) => {
   switch (res.status) {
   case 201:
+    sendMessage(`Csoport sikeresen ${edited ? 'frissítve' : 'létrehozva'}`, 'success')
     location.href = '/groups'
     break
   case 400:
@@ -44,7 +45,7 @@ const addGroup = (event) => {
     errors.forEach((err) => displayMessage(err))
   } else {
     fetch('/groups', { method: 'POST', body: formData })
-      .then(handleResponse)
+      .then((res) => handleResponse(res, false))
       .catch((err) => displayMessage(err))
   }
 }
@@ -64,7 +65,7 @@ const editGroup = (event) => {
     errors.forEach((err) => displayMessage(err))
   } else {
     fetch(`/groups/${groupId}`, { method: 'PUT', body: formData })
-      .then(handleResponse)
+      .then((res) => handleResponse(res, true))
       .catch((err) => displayMessage(err))
   }
 }

--- a/public/js/group/show.js
+++ b/public/js/group/show.js
@@ -3,10 +3,11 @@ const deleteGroup = (id) => {
   fetch(`/groups/${id}`, { method: 'DELETE' })
     .then((res) => {
       if (res.status === 204) {
+        sendMessage('Csoport sikeresen törölve', 'success')
         location.href = '/groups'
       }
     })
-    .catch((err) => console.error(err))
+    .catch((err) => sendMessage(err))
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/public/js/group/show.js
+++ b/public/js/group/show.js
@@ -7,7 +7,7 @@ const deleteGroup = (id) => {
         location.href = '/groups'
       }
     })
-    .catch((err) => sendMessage(err))
+    .catch((err) => displayMessage(err))
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -4,6 +4,7 @@ const UNAUTHORIZED_MESSAGE = 'Ehhez a művelethez bejelentkezés szükséges'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const FORBIDDEN_MESSAGE = 'Ehhez a művelethez admin jogosultság szükséges'
 
+// this function displays a message right away
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function displayMessage(message, type = 'danger') {
   const messageEL = document.createElement('article')
@@ -28,6 +29,25 @@ function displayMessage(message, type = 'danger') {
   messageEL.addEventListener('click', () => messageEL.remove(), { once: true })
   setTimeout(() => messageEL.remove(), 4000)
 }
+
+// this function displays a message on the next reload
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function sendMessage(message, type = 'danger') {
+  document.cookie = `message=${JSON.stringify({
+    mes: message, 
+    type: type
+  })};path=/;SameSite=Lax;`
+}
+
+// display the message that is stored in a cookie
+window.addEventListener('DOMContentLoaded', () => {
+  const cookie = getCookie('message')
+  if (cookie) {
+    const {mes, type} = JSON.parse(cookie)
+    displayMessage(mes, type)
+    document.cookie = 'message= ;path=/;SameSite=Lax;expires = Thu, 01 Jan 1970 00:00:00 GMT'
+  }
+})
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function clearMessages() {

--- a/public/js/ticket.js
+++ b/public/js/ticket.js
@@ -63,6 +63,7 @@ function addTicket() {
       .then(async (res) => {
         switch (res.status) {
         case 201:
+          sendMessage('Hibajegy sikeresen létrehozva', 'success')
           location.href = '/tickets'
           break
         case 400:

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -32,7 +32,7 @@ function updateUser(id) {
           break
         }
       })
-      .catch((err) => console.error(err))
+      .catch((err) => displayMessage(err))
   }
 }
 

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -54,6 +54,7 @@ function updateRole(id) {
       .then(async res => {
         switch (res.status) {
         case 201:
+          sendMessage('Felhasználó rangja sikeresen frissítve', 'success')
           location.href = `/users/${id}`
           break
         case 400:

--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -8,6 +8,7 @@ import { differenceInMinutes } from 'date-fns'
 import { RoleType, User } from '../users/user'
 import { Group } from './group'
 import { asyncWrapper } from '../../util/asyncWrapper'
+import sendMessage from '../../util/sendMessage'
 
 export const joinGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
   const user = req.user as User
@@ -15,9 +16,13 @@ export const joinGroup = asyncWrapper(async (req: Request, res: Response, next: 
 
   // Join group if not already in it, and it's not closed or it's the owner who joins.
   // We only join the group if it is not full already
-  if ((!group.doNotDisturb || (user.id === group.ownerId)) &&
-    !group.users?.find(it => it.id === user.id) &&
-    (group.users?.length || 0) < group.maxAttendees) {
+  if (group.doNotDisturb && (user.id !== group.ownerId)){
+    sendMessage(res, 'Ez egy privát csoport!')
+  } else if (group.users?.find(it => it.id === user.id)) {
+    sendMessage(res, 'Már tagja vagy ennek a csoportnak!')
+  } else if ((group.users?.length || 0) >= group.maxAttendees) {
+    sendMessage(res, 'Ez a csoport már tele van!')
+  } else {
     await Group.relatedQuery('users')
       .for(group.id)
       .relate(user.id)

--- a/src/util/sendMessage.ts
+++ b/src/util/sendMessage.ts
@@ -1,0 +1,10 @@
+import { Response } from 'express'
+
+// type can be danger, success, or warning, as per public/js/main.js displayMessage()
+const sendMessage = (res: Response, message: string, type = 'danger') => {
+  res.cookie('message', JSON.stringify({
+    mes: message, 
+    type: type,
+  }), {path: '/'})
+}
+export default sendMessage


### PR DESCRIPTION
We can now send messages that are persistent between requests. The next time the DOM loads, the message will be displayed.
This can be done with the `sendMessage()` function on both client and server side, with similiar usage (it needs the response object on server side).
With this, I added error and success messages to a bunch of places where it wasn't posibble previously because the page reloaded.
Closes #680 