### PR TITLE
Group improvements

### DIFF
--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -23,6 +23,8 @@ export const joinGroup = asyncWrapper(async (req: Request, res: Response, next: 
     sendMessage(res, 'Már tagja vagy ennek a csoportnak!')
   } else if ((group.users?.length || 0) >= group.maxAttendees) {
     sendMessage(res, 'Ez a csoport már tele van!')
+  } else if (group.endDate < new Date()) {
+    sendMessage(res, 'Ez a csoport már lejárt!')
   } else {
     await Group.relatedQuery('users')
       .for(group.id)

--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -24,7 +24,7 @@ export const joinGroup = asyncWrapper(async (req: Request, res: Response, next: 
   } else if ((group.users?.length || 0) >= group.maxAttendees) {
     sendMessage(res, 'Ez a csoport már tele van!')
   } else if (group.endDate < new Date()) {
-    sendMessage(res, 'Ez a csoport már lejárt!')
+    sendMessage(res, 'Ez a csoport már véget ért!')
   } else {
     await Group.relatedQuery('users')
       .for(group.id)

--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -10,9 +10,9 @@ block content
   div(class='flex flex-row items-center mb-8 mr-4 space-x-4')
     h1(class='truncate title')= group.name
     if groupStarted && !groupEnded
-      p(class="text-2xl text-green-700") Már elkezdődött.
+      p(class="text-2xl text-green-700") Ez a csoport már elkezdődött!
     else if groupEnded
-      p(class="text-2xl text-red-700") Ez a csoport lejárt.
+      p(class="text-2xl text-red-700") Ez a csoport már véget ért!
     if !joined && !group.doNotDisturb && !groupEnded
       form(action=`/groups/${group.id}/join`, method="post")
         button(type="submit" class='text-xl btn btn-primary animate-hover') Csatlakozás

--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -5,12 +5,14 @@ include ../modalTemplate.pug
 block content
   - const [startDate, startTime] = format(group.startDate, DATE_FORMAT).split(' ')
   - const [endDate, endTime] = format(group.endDate, DATE_FORMAT).split(' ')
-  - const now = new Date()
-  - const groupEnded = (group.endDate - now) <= 0
+  - const groupEnded = group.endDate < new Date()
+  - const groupStarted = group.startDate < new Date()
   div(class='flex flex-row items-center mb-8 mr-4 space-x-4')
     h1(class='truncate title')= group.name
-    if groupEnded
-      p(class="text-2xl") Ez a csoport lejárt.
+    if groupStarted && !groupEnded
+      p(class="text-2xl text-green-700") Már elkezdődött.
+    else if groupEnded
+      p(class="text-2xl text-red-700") Ez a csoport lejárt.
     if !joined && !group.doNotDisturb && !groupEnded
       form(action=`/groups/${group.id}/join`, method="post")
         button(type="submit" class='text-xl btn btn-primary animate-hover') Csatlakozás
@@ -111,6 +113,10 @@ block content
                 path(stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z')
               span= startDate
                 strong &nbsp;#{startTime}-#{endTime}
+              if groupStarted && !groupEnded
+                p(class="text-xl text-green-700") Folyamatban.
+              else if groupEnded
+                p(class="text-xl text-red-700") Vége.
           else
             li(class='flex flex-col items-start space-y-4 sm:space-y-0 sm:space-x-6 sm:items-center sm:flex-row')
               div(class='flex flex-row items-center')
@@ -126,6 +132,10 @@ block content
                   path(stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z')
                 span &nbsp;#{endDate}
                   strong &nbsp;#{endTime}
+              if (groupStarted && !groupEnded)
+                p(class="text-xl text-green-700") Folyamatban.
+              else if groupEnded
+                p(class="text-xl text-red-700") Vége.
           if group.tags
             li(class='flex flex-row items-center space-x-2')
               //- Heroicon name: tag

--- a/views/group/show.pug
+++ b/views/group/show.pug
@@ -5,13 +5,17 @@ include ../modalTemplate.pug
 block content
   - const [startDate, startTime] = format(group.startDate, DATE_FORMAT).split(' ')
   - const [endDate, endTime] = format(group.endDate, DATE_FORMAT).split(' ')
+  - const now = new Date()
+  - const groupEnded = (group.endDate - now) <= 0
   div(class='flex flex-row items-center mb-8 mr-4 space-x-4')
     h1(class='truncate title')= group.name
-    if !joined && !group.doNotDisturb
+    if groupEnded
+      p(class="text-2xl") Ez a csoport lejárt.
+    if !joined && !group.doNotDisturb && !groupEnded
       form(action=`/groups/${group.id}/join`, method="post")
         button(type="submit" class='text-xl btn btn-primary animate-hover') Csatlakozás
     else if !isOwner && joined
-      button(type="button" class='text-xl bg-yellow-400 btn btn-primary animate-hover dark:text-black hover:bg-yellow-500' onClick=`toggleModal(
+      button(type="button" class='text-xl bg-yellow-400 btn btn-primary animate-hover text-black dark:text-white hover:bg-yellow-500' onClick=`toggleModal(
         '/groups/${group.id}/leave',
         'Biztosan ki akarsz lépni?',
         'Biztosan ki akarsz lépni a(z) ${group.name} csoportból?',


### PR DESCRIPTION
 Users now can't join a group if it's already over, and instead of the join button there is a text saying that this group has expired.
 The "Kilépés" button's text color changed to black in light mode and to white in dark mode in order to match the others and for contrast improvements.
 Closes #741 