### PR TITLE
bug/crash-after-midnight

### DIFF
--- a/src/components/rooms/room.service.ts
+++ b/src/components/rooms/room.service.ts
@@ -50,7 +50,7 @@ const parseUsageData = (rawData: RawUsageData[], today: Date): ParsedUsageData =
 
   // fill data
   for (const { room, day, count } of rawData) {
-    const daysUntil = differenceInDays(day, today)
+    const daysUntil = Math.max(0, differenceInDays(day, today))
     if (room) {
       result.get(room)[daysUntil].count = Number(count)
     }


### PR DESCRIPTION
If an event started yesterday and ends today, differenceInDays will be -1 as it is calculated from the start of the event.
However valid values are 0..=6

Fixes #828