### PR TITLE
Type definition for req.user

### DIFF
--- a/src/components/groups/group.middlewares.ts
+++ b/src/components/groups/group.middlewares.ts
@@ -12,7 +12,7 @@ import sendMessage from '../../util/sendMessage'
 import { sendEmail } from '../../util/sendEmail'
 
 export const joinGroup = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
-  const user = req.user as User
+  const user = req.user
   const group = req.group
 
   // Join group if not already in it, and it's not closed or it's the owner who joins.
@@ -36,7 +36,7 @@ export const joinGroup = asyncWrapper(async (req: Request, res: Response, next: 
 
 export const sendEmailToOwner = asyncWrapper(
   async (req: Request, res: Response, next: NextFunction) =>  {
-    const user = req.user as User
+    const user = req.user
     const group = req.group
 
     const emailRecepient = await User.query().findOne({ id: group.ownerId })
@@ -52,7 +52,7 @@ export const leaveGroup = asyncWrapper(async (req: Request, res: Response, next:
   await Group.relatedQuery('users')
     .for(req.group.id)
     .unrelate()
-    .where('user_id', (req.user as User).id)
+    .where('user_id', req.user.id)
 
   next()
 })
@@ -92,7 +92,7 @@ export const sendEmailToMember = asyncWrapper(
  */
 export const isGroupOwner = asyncWrapper(
   async (req: Request, res: Response, next: NextFunction) => {
-    if ((req.user as User)?.id === req.group.ownerId) {
+    if (req.user?.id === req.group.ownerId) {
       next()
     } else {
       res.render('error/forbidden')
@@ -102,8 +102,8 @@ export const isGroupOwner = asyncWrapper(
 
 export const isGroupOwnerOrAdmin = asyncWrapper(
   async (req: Request, res: Response, next: NextFunction) => {
-    if (((req.user as User)?.id === req.group.ownerId)
-      || ((req.user as User)?.role == RoleType.ADMIN)) {
+    if ((req.user?.id === req.group.ownerId)
+      || (req.user?.role == RoleType.ADMIN)) {
       next()
     } else {
       res.render('error/forbidden')

--- a/src/components/groups/group.routes.ts
+++ b/src/components/groups/group.routes.ts
@@ -10,7 +10,7 @@ import multer from 'multer'
 import { isAuthenticated } from '../../config/passport'
 import { DATE_FORMAT, ROOMS } from '../../util/constants'
 import { handleValidationError, checkIdParam } from '../../util/validators'
-import { RoleType, User } from '../users/user'
+import { RoleType } from '../users/user'
 import {
   joinGroup,
   sendEmailToOwner,
@@ -67,9 +67,9 @@ router.get('/:id',
   checkIdParam,
   getGroup,
   (req, res) => {
-    const joined = req.group.users.some(u => u.id === (req.user as User).id)
-    const isOwner = req.group.ownerId === (req.user as User).id
-    const isAdmin = (req.user as User).role == RoleType.ADMIN
+    const joined = req.group.users.some(u => u.id === req.user.id)
+    const isOwner = req.group.ownerId === req.user.id
+    const isAdmin = req.user.role == RoleType.ADMIN
     res.render('group/show', {
       group: req.group, joined, isOwner, format, DATE_FORMAT, isAdmin
     })

--- a/src/components/groups/group.service.ts
+++ b/src/components/groups/group.service.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction} from 'express'
 
 import { Group } from './group'
-import { User } from '../users/user'
 import { formatMdToSafeHTML } from '../../util/convertMarkdown'
 import { asyncWrapper } from '../../util/asyncWrapper'
 
@@ -52,7 +51,7 @@ export const createGroup = asyncWrapper(async (req: Request, res: Response, next
         doNotDisturb: !!req.body.doNotDisturb,
         startDate: new Date(req.body.startDate),
         endDate: new Date(req.body.endDate),
-        ownerId: (req.user as User).id,
+        ownerId: req.user.id,
         maxAttendees: parseInt(req.body.maxAttendees) || 100
       }
     )

--- a/src/components/tickets/ticket.service.ts
+++ b/src/components/tickets/ticket.service.ts
@@ -10,7 +10,7 @@ import { User } from '../users/user'
 
 export const getOtherTickets = asyncWrapper(
   async (req: Request, _res: Response, next: NextFunction) => {
-    req.otherTickets = (await Ticket.query().where('userId', '!=', (req.user as User).id)
+    req.otherTickets = (await Ticket.query().where('userId', '!=', req.user.id)
       .orderBy('createdAt', 'ASC')).map(ticket => {
       ticket.description = formatMdToSafeHTML(ticket.description)
       return ticket
@@ -20,7 +20,7 @@ export const getOtherTickets = asyncWrapper(
 
 export const getMyTickets = asyncWrapper(
   async (req: Request, _res: Response, next: NextFunction) => {
-    req.myTickets = (await Ticket.query().where('userId', '=', (req.user as User).id)
+    req.myTickets = (await Ticket.query().where('userId', '=', req.user.id)
       .orderBy('createdAt', 'ASC')).map(ticket => {
       ticket.description = formatMdToSafeHTML(ticket.description)
       return ticket
@@ -36,7 +36,7 @@ export const createTicket = asyncWrapper(
           {
             roomNumber: +req.body.roomNumber,
             description: req.body.description,
-            userId: (req.user as User).id,
+            userId: req.user.id,
           }
         )
     })
@@ -84,7 +84,7 @@ export const removeTicket = asyncWrapper(
 export const checkTicketOwner = asyncWrapper(
   async (req: Request, res: Response, next: NextFunction) => {
     const ticket = await Ticket.query().findOne({ id: parseInt(req.params.id) })
-    if (ticket.userId == (req.user as User).id) {
+    if (ticket.userId == req.user.id) {
       next()
     } else {
       return res.sendStatus(403)

--- a/src/components/users/user.middlewares.ts
+++ b/src/components/users/user.middlewares.ts
@@ -1,9 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 
-import { User } from './user'
-
 export const isSameUser = (req: Request, res: Response, next: NextFunction): void => {
-  if (parseInt(req.params.id) !== (req.user as User).id) {
+  if (parseInt(req.params.id) !== req.user.id) {
     res.status(400).json({ errors: [{ msg: 'Nem találahtó felhasználó a megadott ID-val' }] })
   } else {
     next()

--- a/src/components/users/user.routes.ts
+++ b/src/components/users/user.routes.ts
@@ -4,7 +4,7 @@ import { ROLES } from '../../util/constants'
 
 import { requireRoles, isAuthenticated } from '../../config/passport'
 import { handleValidationError, checkIdParam } from '../../util/validators'
-import { RoleType, User } from './user'
+import { RoleType } from './user'
 import { isSameUser } from './user.middlewares'
 import { getUser, updateRole, updateUser } from './user.service'
 
@@ -21,7 +21,7 @@ router.patch('/:id/role',
   requireRoles(RoleType.ADMIN),
   check('role')
     .isString()
-    .custom((input) => { 
+    .custom((input) => {
       return [...ROLES.keys()]
         .some((element) => element == input)
     })
@@ -34,7 +34,7 @@ router.patch('/:id/role',
 router.patch('/:id',
   isAuthenticated,
   (req, res, next) => {
-    if ((req.user as User).id !== parseInt(req.params.id)) {
+    if (req.user.id !== parseInt(req.params.id)) {
       return res.sendStatus(403)
     }
     next()

--- a/src/components/users/user.service.ts
+++ b/src/components/users/user.service.ts
@@ -41,7 +41,7 @@ export const updateRole = asyncWrapper(async (req: Request, res: Response, next:
 })
 
 export const updateUser = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {
-  const id = (req.user as User).id
+  const id = req.user.id
   const { floor, wantEmail } = req.body
   req.user = await User.query().patchAndFetchById(id, { floor, wantEmail })
 

--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -79,7 +79,7 @@ export const isAuthenticated =
 export const requireRoles = (...roles: RoleType[]) => {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   return (req: Request, res: Response, next: NextFunction): Response<any, Record<string, any>> => {
-    const role = (req.user as User)?.role
+    const role = req.user?.role
     if (roles.some((element) => role == element)) {
       next()
     } else {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -13,6 +13,8 @@ declare global {
       group: Group
       userToShow: LocalUser
     }
+
+    interface User extends LocalUser {}
   }
 }
 


### PR DESCRIPTION
By defining a User inteface inside express we can tell express the type of the req.user object.

Previously we had to cast req.user to User, every time we used it.

Now no casts are needed, as req.user already has the type of User.

`yarn build:prod` runs successfully and vscode provides autointel on req.user