### PR TITLE
Floor selector defaults to your preferred floor when creating a new group

### DIFF
--- a/views/group/new.pug
+++ b/views/group/new.pug
@@ -28,7 +28,7 @@ block content
         div(class='flex flex-row items-center space-x-4')
           select(name="room", id="floorInput", class='rounded form-element')
             each room in ROOMS
-              if roomId == room
+              if roomId == room || !roomId && user.floor == room
                 option(value=`${room}`, selected='selected')= room
               else
                 option(value=`${room}`)= room


### PR DESCRIPTION
If you're coming from the /groups page. If you click on one of the Reserve button on the mainpage, it will still default to that floor.
Closes #871 