### PR TITLE
make email nullable in user schema

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
   },
   "typescript.referencesCodeLens.enabled": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "files.insertFinalNewline": true,
   "eslint.enable": true

--- a/migrations/20240510212804_nullable_email.ts
+++ b/migrations/20240510212804_nullable_email.ts
@@ -1,0 +1,16 @@
+import * as Knex from 'knex'
+
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('users', table => {
+    table.string('email').nullable().alter()
+  })
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('users', table => {
+    table.string('email').notNullable().alter()
+  })
+}
+

--- a/src/components/tickets/ticket.service.ts
+++ b/src/components/tickets/ticket.service.ts
@@ -47,7 +47,10 @@ export const sendEmailToTicketAdmins = asyncWrapper(
   async (req: Request, res: Response, next: NextFunction) =>  {
     const ticket = req.body
 
-    const emailRecepients = await User.query().where({ role: RoleType.TICKET_ADMIN })
+    const emailRecepients = await User
+      .query()
+      .where({ role: RoleType.TICKET_ADMIN })
+      .whereNotNull('email')
     sendEmail(emailRecepients, {
       subject: `Új hibajegyet vettek fel a ${ticket.roomNumber}. emeleti tanulószobába!`,
       body: `Új hibajegyet vettek fel a ${ticket.roomNumber}. emeleti tanulószobába!

--- a/src/components/users/user.service.ts
+++ b/src/components/users/user.service.ts
@@ -6,7 +6,7 @@ import { asyncWrapper } from '../../util/asyncWrapper'
 interface OAuthUser {
   displayName: string
   internal_id: string
-  mail: string
+  mail?: string
 }
 
 export const getUser = asyncWrapper(async (req: Request, res: Response, next: NextFunction) => {

--- a/src/components/users/user.ts
+++ b/src/components/users/user.ts
@@ -12,7 +12,7 @@ export enum RoleType {
 export class User extends Model {
   id!: number
   name: string
-  email: string
+  email?: string
   authSchId: string
   role: RoleType
   floor: number
@@ -45,7 +45,7 @@ export class User extends Model {
   static get jsonSchema(): Record<string, any> {
     return {
       type: 'object',
-      required: ['name', 'email', 'authSchId'],
+      required: ['name', 'authSchId'],
 
       properties: {
         id: { type: 'integer' },


### PR DESCRIPTION
AuthSCH doesn't always send the email address of a user. Since this data isn't too important in this app and we don't use it to identify users, we can still create the user.

Let's hope that ChatGPT knows how knex works, because I certainly don't remember. 